### PR TITLE
Allow to configure options on the FacetSet

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -11,6 +11,13 @@ use Laravel\Scout\Builder as ScoutBuilder;
 class Builder extends ScoutBuilder
 {
     /**
+     * Array of options for the facetSet. <option> => <value> format
+     *
+     * @var string[]
+     */
+    public $facetOptions = [];
+
+    /**
      * Array of facet fields to facet on.
      *
      * @var string[]
@@ -161,6 +168,22 @@ class Builder extends ScoutBuilder
     public function facetPivot(array $fields)
     {
         $this->facetPivots[] = $fields;
+
+        return $this;
+    }
+
+    /**
+     * Add an option to apply on the Solarium FacetSet
+     * See https://github.com/solariumphp/solarium/blob/master/src/Component/FacetSet.php for possible options
+     *
+     * @param  string $option The option name
+     * @param  mixed  $value  The option value
+     *
+     * @return self  To allow for fluent chaining
+     */
+    public function setFacetOption($option, $value)
+    {
+        $this->facetOptions[$option] = $value;
 
         return $this;
     }

--- a/src/Engines/SolrEngine.php
+++ b/src/Engines/SolrEngine.php
@@ -193,7 +193,7 @@ class SolrEngine extends Engine
     /**
      * Actually perform the search, allows for options to be passed like pagination.
      *
-     * @param \Laravel\Scout\Builder $builder The query builder we were passed
+     * @param Builder $builder The query builder we were passed
      * @param array $options An array of options to use to do things like pagination, faceting?
      *
      * @return \Solarium\Core\Query\Result\Result The results of the query
@@ -238,6 +238,7 @@ class SolrEngine extends Engine
 
         // build any faceting
         $facetSet = $query->getFacetSet();
+        $facetSet->setOptions($builder->facetOptions);
         if (! empty($builder->facetFields)) {
             foreach ($builder->facetFields as $field) {
                 $facetSet->createFacetField("$field-field")->setField($field);


### PR DESCRIPTION
Hi,

For a project I have more than the default 100 facet results so I need to set the limt on the `FacetSet` instance.

Instead of creating methods for each possible options, I decided to create an array of options and setting them all in one go using `setOptions`.

What do you think ?