### PR TITLE
BUG: Space in placeholder logic

### DIFF
--- a/src/Engines/SolrEngine.php
+++ b/src/Engines/SolrEngine.php
@@ -389,7 +389,7 @@ class SolrEngine extends Engine
             $end = $start + count($items);
             $query = collect(range($start + 1, $end))
                 ->map(function (int $index) use ($field, $mode): string {
-                    return "$field:%$mode $index%";
+                    return "{$field}:%{$mode}{$index}%";
                 })->implode(' OR ');
             $start = $end;
         }


### PR DESCRIPTION
The space between the placeholder mode and the index was causing errors to throw